### PR TITLE
Update package.json to include branch name

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ghost": "^4.7.0",
     "ghost-storage-adapter-s3": "^2.8.0",
     "ghost-storage-cloudinary": "^2.1.5",
-    "lyra": "github:TryGhost/lyra#master",
+    "lyra": "github:TryGhost/lyra#main",
     "mysql": "^2.18.1"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

It seems that the `master` branch was replaced for `main` breaking the button when using it in Heroku